### PR TITLE
Add AuthProvider with localStorage-based authentication

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type User = {
+    email: string,
+    password: string,
+    username?: string
+}
+
+type AuthContextType = {
+    user: User | null,
+    signup: (email: string, password: string, username?: string) => boolean,
+    login: (email: string, password: string, remember: boolean) => boolean,
+    logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({children}: { children: React.ReactNode }) {
+    const [user, setUser] = useState<User | null>(null);
+
+    // Load user from local storage on startup
+    useEffect(() => {
+        const savedUser = localStorage.getItem("user") || sessionStorage.getItem("user");
+        if (savedUser) {
+            setUser(JSON.parse(savedUser));
+        }
+        // console.log("savedUser", savedUser);
+    }, [])
+
+    const signup = (email: string, password: string, username?: string) => {
+        const users = JSON.parse(localStorage.getItem("users") || "[]");
+
+        // prevent duplicate signup
+        if (users.find((u: User) => u.email === email)) {
+            alert("User already exists");
+            return false;
+        }
+
+        const newUser: User = { email, password, username };
+        users.push(newUser);
+        localStorage.setItem("users", JSON.stringify(users));
+        alert("Signup successful, you can log in");
+        return true;
+    }
+
+    const login = (email: string, password: string, remember: boolean) => {
+        const users: User[] = JSON.parse(localStorage.getItem("users") || "[]");
+
+        const existingUser = users.find(
+            (u) => u.email === email && u.password === password
+        );
+
+        // user not found
+        if (!existingUser) {
+            alert("Invalid credentials");
+            return false;
+        }
+
+        // persist session
+        if (remember) {
+            localStorage.setItem("user", JSON.stringify(existingUser));
+        } else  {
+            sessionStorage.setItem("user", JSON.stringify(existingUser));
+        }
+
+        setUser(existingUser);
+        return true;
+    }
+
+    const logout = () => {
+        localStorage.removeItem("user");
+        sessionStorage.removeItem("user");
+        setUser(null);
+    }
+
+    return (
+        <AuthContext.Provider value={{ user, signup, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    )
+}
+
+export const useAuth = () => {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error("useAuth must be used inside AuthProvider");
+    }
+    return context
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "./context/AuthContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthProvider>
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/ui/AuthForm.tsx
+++ b/src/components/ui/AuthForm.tsx
@@ -3,6 +3,7 @@
 import React from "react"
 import { useState } from "react";
 import { useForm } from "react-hook-form"
+import { useAuth } from "@/app/context/AuthContext";
 import { Mail, Lock, User } from "lucide-react"
 import Image from "next/image";
 import quillIcon from "../../../public/quill-icon.png"
@@ -16,6 +17,7 @@ type FormInputs = {
 }
 
 export default function AuthForm() {
+  const { user, signup, login, logout } = useAuth();
   const [mode, setMode] = useState<"login" | "signup">("login");
 
   const {
@@ -24,22 +26,58 @@ export default function AuthForm() {
     watch,
     formState: { errors },
     reset,
-  } = useForm<FormInputs>()
+  } = useForm<FormInputs>();
 
   const passwordValue = watch("password");
 
    const onSubmit = (data: FormInputs) => {
-    if (mode === "login") {
-      console.log("Logging in:", data)
-      // TODO: call login API
-    } else {
-      console.log("Signing up:", data)
-      // TODO: call signup API
-    }
-    // pass `data.rememberMe` to backend/session logic
+    if (mode === "signup") {
+      if (data.password !== data.confirmPassword) {
+        alert("Passwords do not match");
+        return;
+      }
 
+      const success = signup(data.email, data.password, data.username);
+      if (success) {
+        setMode("login"); // switch to login after signup
+        reset();
+      }
+
+    } else {
+        const success = login(data.email, data.password, !!data.rememberMe);
+        if (success) {
+            reset();
+        }
+    }
     // wipe fields
     reset();
+  }
+
+  if (user) {
+    return (
+      <div className="flex-1 bg-gray-200 flex flex-col items-center justify-center p-8 min-h-screen">
+        <div className="flex items-center justify-center text-center">
+         <Image
+            src={quillIcon}
+            height={150}
+            width={150}
+            alt=""
+          />
+          <div className="flex items-center text-gray-700 text-4xl">
+            Compendia
+          </div>
+        </div>
+        <h2 className="w-full max-w-md flex items-center justify-center m-4 space-y-8 text-2xl text-gray-700">
+          Welcome, {user.username || user.email}!
+        </h2>
+        <button
+          onClick={logout}
+          className="w-full h-12 bg-red-500 m-4 hover:bg-red-600 text-white rounded-md"
+        >
+          Logout
+        </button>
+      </div>
+    )
   }
 
   return (
@@ -173,7 +211,7 @@ export default function AuthForm() {
               type="submit"
               className="w-full h-12 bg-black hover:bg-gray-800 text-white rounded-md"
             >
-              {mode === "login" ? "Sign Up" : "Sign In"}
+              {mode === "login" ? "Sign In" : "Sign Up"}
             </button>
           </form>
 


### PR DESCRIPTION
### Description
- Implemented AuthProvider using React Context to manage authentication state
- Added signup, login, logout functionality with localStorage persistence
- Added "Remember Me" support (localStorage vs sessionStorage)
- Integrated AuthForm with context

### Why
- Provides basic authentication flow without requiring a database
- Allows quick prototyping of user sessions
- Sets up foundation for migrating to NextAuth + Prisma + Neon in future

### Next Steps
- Replace localStorage-based auth with NextAuth
- Store users in PostgreSQL via Prisma
- Add password hashing for security
