### PR TITLE
Connect MarketingPage UI to Summarize API

### DIFF
--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+type SummaryType = "brief" | "detailed" | "bullet";
+
+export async function POST(req: Request) {
+    try {
+        const { content, summaryType } = await req.json() as {
+            content: string;
+            summaryType: SummaryType;
+        }
+
+        if (!content || !summaryType) {
+            return NextResponse.json({ error: "Missing content or summaryType"}, { status: 400 });
+        }
+
+        // 🔹 Mock summary generator (replace later with AI)
+        const sentences = content
+            .split(/[.!?]+/)
+            .filter((s) => s.trim().length > 0);
+
+        let summary = "";
+
+        if (summaryType === "bullet") {
+            summary = sentences.slice(0, 3).map((s) => `• ${s.trim()}`).join("\n");
+        } else if (summaryType === "detailed") {
+            summary = sentences.slice(0, 4).join(". ") + (sentences.length > 4 ? "..." : "");
+        } else {
+        // brief
+            summary = sentences.slice(0, 2).join(". ") + (sentences.length > 2 ? "..." : "");
+        }
+
+        return NextResponse.json({ summary });
+
+    } catch (error) {
+        console.error("Summarize API error: ", error);
+    }
+}


### PR DESCRIPTION
### Summary
This PR connects the MarketingPage UI to the new /api/summarize route, replacing the temporary client-side summary generation logic. Users can now create, edit, and regenerate notes with summaries fetched from the backend API.

### Changes
- Added `generateSummary` helper to POST note content and summary type 
  to `/api/summarize`.
- Updated `handleSubmit` to request summaries from the API when creating 
  or editing notes.
- Updated `regenerateSummary` to fetch a new summary when switching 
  summary types.
- Introduced `isGeneratingSummary` state to show loading spinner and 
  disable inputs during API requests.
- Removed temporary inline summary generation logic from the UI.

### Why
The previous summary implementation was purely client-side and only meant for prototyping. Moving the logic to an API route allows us to later integrate with a real AI provider (e.g., OpenAI) without changing the UI again. This separation keeps the frontend clean and lays the groundwork for production-ready summarization.
